### PR TITLE
Github does not understand ~~~ code blocks in Readme.mkd - Fixed for github

### DIFF
--- a/EMongoEmbeddedDocument.php
+++ b/EMongoEmbeddedDocument.php
@@ -5,7 +5,7 @@ abstract class EMongoEmbeddedDocument extends CModel
 	private static $_names=array();
 
 	/**
-	 * CMap of embded documents
+	 * CMap of embedded documents
 	 * @var CMap $_embedded
 	 */
 	protected $_embedded=null;

--- a/README.mkd
+++ b/README.mkd
@@ -10,120 +10,121 @@ Some key features:
 - Records and embedded documents inherit from CModel, so you can use every class witch can handle of CModel (ie: Gii form generator)
 - relation support *idea/concept/example*
 
-*IMPORTANT: please use github version, keeping track of bugfixes and updating this download is hard to catch up*
+*IMPORTANT: please use github version, keeping track of bug fixes and updating this download is hard to catch up*
 
 ##Requirements
 
 I've tested it only with Yii 1.1.4
-it took me long night to write this initial stage, so it may have some bugs, help with testing needed ! :) 
+it took me long night to write this initial stage, so it may have some bugs, help with testing needed ! :)
 
 ##Basic usage
 
-Just create a model class as You would with normal ActiveRecord
+Just create a model class as You would with normal ActiveRecord.
 
-~~~
-[php]
-// example model simple as standard AcriveRecord
-class Client extends EMongoRecord
-{
-    public $personal_number;
-    public $first_name;
-    public $last_name;
+Example model simple as standard ActiveRecord:
 
-    // this method must be implemented (its defined as abstract anyway), it have to return Mongo collection name for use with this record(s)
-    public function collectionName()
+    class Client extends EMongoRecord
     {
-        return 'clients';
+        public $personal_number;
+        public $first_name;
+        public $last_name;
+
+        // this method must be implemented (its defined as abstract anyway), it have to return Mongo collection name for use with this record(s)
+        public function collectionName()
+        {
+            return 'clients';
+        }
+
+        public function rules()
+        {
+            return array(
+                array('personal_number, first_name, last_name', 'required'),
+            );
+        }
+
+        public function attributeLabels()
+        {
+            return array(
+                'personal_number'=>'PN',
+            );
+        }
+
+        // EVERY model has to have this! (same as CActiveRecord child classes)
+        public static function model($className=__CLASS__)
+        {
+            return parent::model($className);
+        }
     }
 
-    public function rules()
-    {
-        return array(
-            array('personal_number, first_name, last_name', 'required'),
-        );
-    }
 
-    public function attributeLabels()
-    {
-        return array(
-            'personal_number'=>'PN',
-        );
-    }
-
-    // EVERY model has to have this! (same as CActiveRecord child classes)
-    public static function model($className=__CLASS__)
-    {
-        return parent::model($className);
-    }
-}
-/*
 And this is it ! use this object just as regular ActiveRecord
 for instance:
-$client = new Client;
-$client->first_name='somethin';
-$client->save();
-$clients = Client::model->findAll();
+
+    $client = new Client;
+    $client->first_name='something';
+    $client->save();
+    $clients = Client::model->findAll();
+
 etc.
-*/
-~~~
+
 
 ##Embedded documents
 
 *IMPORTANT: Embedded documents must extend from EMongoEmbeddedDocument instead of EMongoRecord, otherwise whole thing will fail, to work*
 *Note: some people reported that embedding regular EMongoRecord works as expected, but i have not tested this, more test/reports needed*
 
-
-~~~
-[php]
-/*
 Embedded documents are almost identical as EMongoRecord you only can't save them to DB they're saved by the EMongoRecord model witch has them as an embedded (with one exception, you can save them if you will do it explicitly)
-Notice: Emnded documents don have static model() method!
+Notice: Embedded documents don have static model() method!
 
 Lest assume we have following embedded document:
-*/
-class ClientAddress extends EMongoEmbeddedDocument
-{
-    public $city;
-    public $street;
-    public $house;
-    public $apartment;
-    public $zip;
 
-    public function rules()
+    class ClientAddress extends EMongoEmbeddedDocument
+    {
+        public $city;
+        public $street;
+        public $house;
+        public $apartment;
+        public $zip;
+
+        public function rules()
+        {
+            return array(
+                array('city, street, house', 'length', 'max'=>255),
+                array('house, apartment, zip', 'length', 'max'=>10),
+            );
+        }
+
+        public function attributeLabels()
+        {
+            return array(
+                'zip'=>'Postal Code',
+            );
+        }
+    }
+
+Now we can add this method to our Client model from previous section:
+
+//Client model body (...)
+
+    public function embeddedDocuments()
     {
         return array(
-            array('city, street, house', 'length', 'max'=>255),
-            array('house, apartment, zip', 'length', 'max'=>10),
+            'address'=>'ClientAddress' // property name => embedded document class name
         );
     }
 
-    public function attributeLabels()
-    {
-        return array(
-            'zip'=>'Postal Code',
-        );
-    }
-}
-
-// Now we can add this method to our Client model from previous section:
-// Client model body (...)
-public function embeddedDocuments()
-{
-    return array(
-        'address'=>'ClientAddress' // property name => embedded document class name
-    );
-}
 // Client model body (...)
 
-// Now start the fun part!
+Now start the fun part!
 
-$client = new Client;
-$client->address->city='New York';
-$client->save();
-// it will automatically call validation for model and all embedded documents!
-// You even can nest embedded documents in embedded documents, just define embeddedDocuments() method with array of another embedded documents
-// IMPORTANT: This mechanism uses recurency, and will not handle with circular nesting, you have to use this feature with care :P
-~~~
+    $client = new Client;
+    $client->address->city='New York';
+    $client->save();
+
+it will automatically call validation for model and all embedded documents!
+You even can nest embedded documents in embedded documents, just define embeddedDocuments() method with array of another embedded documents
+*IMPORTANT*: This mechanism uses recurrency, and will not handle with circular nesting, you have to use this feature with care :P
+
 
 ##Arrays
 
@@ -135,69 +136,70 @@ You easily can store arrays in DB!
 
 **Arrays of embedded documents**
 
-- there is no way (i know for now) witch i can easily provide mechanism for this, you have to write Your own
-- i do this in that way:
+- there is no way (that i know) where i can easily provide mechanism for this, you have to write Your own
+- This is how I accomplish it for now:
 
-~~~
-[php]
 
-// add property for yours array od embedded documents
-public $adresses;
+add a property for your array of embedded documents
+    public $addresses;
 
-// add EmbeddedArraysBehavior
-public function behaviors()
-{
-    return array(
-        array(
-            'class'=>'ext.YiiMongoDbSiute.extra.EEmbeddedArraysBehavior',
-            'arrayPropertyName'=>'addresses', // name of property
-            'arrayDocClassName'=>'ClientAddress' // class name of documents in array
-        ),
-    );
-}
+add EmbeddedArraysBehavior
 
-// now You can do:
+    public function behaviors()
+    {
+        return array(
+            array(
+                'class'=>'ext.YiiMongoDbSuite.extra.EEmbeddedArraysBehavior',
+                'arrayPropertyName'=>'addresses', // name of property
+                'arrayDocClassName'=>'ClientAddress' // class name of documents in array
+            ),
+        );
+    }
 
-$c = new Client;
-$c->addresses[0] = new ClientAddress;
-$c->addresses[0]->city='NY';
-$c->save(); // behavior will handle validation of array to
-// or
+now You can do:
 
-$c = Client::model()->find();
-foreach($c->addresses as $addr)
-{
-    echo $addr->city;
-}
+    $c = new Client;
+    $c->addresses[0] = new ClientAddress;
+    $c->addresses[0]->city='NY';
+    $c->save(); // behavior will handle validation of array too
 
-~~~
+or
+
+    $c = Client::model()->find();
+    foreach($c->addresses as $addr)
+    {
+        echo $addr->city;
+    }
 
 ##Querying
 
-~~~
-[php]
-// simple find first
-$object = ModelClass::model->find()
 
-// you can pass a query (witch is an simple array)
-$object = ModelClass::model()->find(array('personal_number'=>12345));
-// for reference on how to use query array see: http://www.php.net/manual/en/mongocollection.find.php
+simple find first
+    $object = ModelClass::model->find()
 
-// finding multiple records
-// simple case by attributes:
-$records = ModelClass::model()->findAllByAttributes(array('city'=>'New York'));
+you can pass a query (which is an simple array)
 
-// findAll* methods accepts additional 3 arguments $sort, $limit and $offest refer to PHP manual for how to use them: http://www.php.net/manual/en/class.mongocursor.php
+    $object = ModelClass::model()->find(array('personal_number'=>12345));
 
-// more advanced case:
-$records = ModelClass::model()->findAll(
-    array('personal_numer'=>array('$mod'=>array(10, 0))), // modulo: personal_number % 10 == 0
-    array('first_name'=>1), // sort by first name ascending
-    10, // limit to 10 records
-    25 // offset 25 / skip first 25 matches
-);
-// analogical this examples also apply to count* methods and delete* methods
-~~~
+for reference on how to use query array see: http://www.php.net/manual/en/mongocollection.find.php
+
+finding multiple records
+simple case by attributes:
+
+    $records = ModelClass::model()->findAllByAttributes(array('city'=>'New York'));
+
+findAll* methods accepts additional 3 arguments $sort, $limit and $offset refer to PHP manual for how to use them:
+http://www.php.net/manual/en/class.mongocursor.php
+
+ more advanced case:
+    $records = ModelClass::model()->findAll(
+        array('personal_number'=>array('$mod'=>array(10, 0))), // modulo: personal_number % 10 == 0
+        array('first_name'=>1), // sort by first name ascending
+        10, // limit to 10 records
+        25 // offset 25 / skip first 25 matches
+    );
+
+analogical this examples also apply to count* methods and delete* methods
 
 ##Relations
 
@@ -205,37 +207,41 @@ $records = ModelClass::model()->findAll(
 
 - In NoSQL World Relations are not so obvious as in RDBMS
 - Because NoSQL databases are designed for performance, there is no need of defining something more complex than correct use of find() method and indexing for fetching related records
-- This is just an *idea/concept/example* you can do things in yours preferred way! this is shema-less wold, think different!
+- This is just an *idea/concept/example* you can do things in yours preferred way! this is schema-less wold, think different!
 - MongoDB Documentation has a clean examples and how-to's for handling relations, *please* read them for better understanding of relations in NoSQL world
 
-~~~
-[php]
+###HAS_ONE relation
 
-// basic HAS_ONE like relation
-// just define method in yours model class (assume we have client collection, and address colection
-// in client model
-public function address()
-{
-    return Address::model()->findByAttributes(array('attribute_with_client_id'=>$this->primaryKey));
-}
+just define method in yours model class (assume we have client collection, and address collection
+in client model
 
-// basic BELONGS_TO relation
-// define in address model
-public function client()
-{
-    return Client::model()->findByPk($this->attribute_with_client_id);
-}
+    public function address()
+    {
+        return Address::model()->findByAttributes(array('attribute_with_client_id'=>$this->primaryKey));
+    }
 
-// basic HAS_MANY relation
-// assume we have clients and orders collection
-// define in client
-public function orders()
-{
-    return Client::model()->findAllByAttributes(array('client_id'=>$this->primaryKey()));
-}
+###BELONGS_TO relation
 
-// MANY_MANY is as simple as defining reverse HAS_MANY relation in orders model
-~~~
+define in address model
+
+    public function client()
+    {
+        return Client::model()->findByPk($this->attribute_with_client_id);
+    }
+
+###HAS_MANY relation
+
+assume we have clients and orders collection
+define in client
+
+    public function orders()
+    {
+        return Client::model()->findAllByAttributes(array('client_id'=>$this->primaryKey()));
+    }
+
+###MANY_MANY
+
+As simple as defining reverse HAS_MANY relation in orders model
 
 ##Gii support
 
@@ -256,41 +262,38 @@ public function orders()
 
 ##DataProvider
 
-~~~
-[php]
-// basic dataprovider returns whole collection (with efficient pagination support out-of-box)
-$dp = new EMongoRecordDataProvider('modelClassNameOrInstance');
+basic dataprovider returns whole collection (with efficient pagination support out-of-box)
 
-// data provider with query
-$dp = new EMongoRecordDataProvider('modelClassNameOrInstance', array(/* query array goes heare */));
+    $dp = new EMongoRecordDataProvider('modelClassNameOrInstance');
 
-// data provider, enable sorting (needs to be set explicit)
-$dp = new EMongoRecordDataProvider('modelClassNameOrInstance', array(/* query array goes heare */), array(/* standard config array */
-    'sort'=>array(
-        'attributes'=>array(
-            // list of sortable attributes
-        )
-    ),
-));
-~~~
+data provider with query
+
+    $dp = new EMongoRecordDataProvider('modelClassNameOrInstance', array(/* query array goes here */));
+
+data provider, enable sorting (needs to be set explicit)
+
+    $dp = new EMongoRecordDataProvider('modelClassNameOrInstance', array(/* query array goes here */), array(/* standard config array */
+        'sort'=>array(
+            'attributes'=>array(
+                // list of sortable attributes
+            )
+        ),
+    ));
 
 ##Setup
 
-~~~
-[php]
-//just add this to yours import array in config file:
-// (...)
-'ext.YiiMongoDbSiute.*',
-// (...)
-//and add component declaration:
-// (...)
-'mongodb'=>array(
-    'class'=>'EMongoDbConnection',
-    'dbName'=>'database_name',
-    'fsyncFlag'=>true // whatever to use fsync flag with internal DB operations
-),
-// (...)
-~~~
+
+Add this to the *import* array in your main.cfg:
+
+    'ext.YiiMongoDbSuite.*',
+
+And add the component declaration:
+
+    'mongodb'=>array(
+        'class'=>'EMongoDbConnection',
+        'dbName'=>'database_name',
+        'fsyncFlag'=>true // whatever to use fsync flag with internal DB operations
+    ),
 
 ##Special topics
 
@@ -303,28 +306,24 @@ $dp = new EMongoRecordDataProvider('modelClassNameOrInstance', array(/* query ar
 
 - By default all save/update/delete operations performed by internal command sets the FSYNC flag to TRUE, this means, all operations will have to wait for a disk sync!
 - FSYNC in most cases is a good way and do not have massive impact on performance
-- You may want to disable FSYNC flag when doing massive imports/updates/dels, because it will be **horrible** slow!
+- You may want to disable FSYNC flag when doing massive imports/updates/models, because it will be **horrible** slow!
 - Fsync can be disabled by setting up fsyncField in EMongoDbConnection class
 
 **Massive hand operations**
 
-example massive hand insert:
+Example mass insert (you will want to disable fsyncField for this:
 
-~~~
-[php]
-
-for($i=0; $i<1000; $i++)
-{
-    $c = new Client;
-    $c->personal_number = $i;
-    $c->validate(); // You can ommit this if you whant
-    $c->getCollection()->insert($c->toArray());
-}
-~~~
+    for($i=0; $i<1000; $i++)
+    {
+        $c = new Client;
+        $c->personal_number = $i;
+        $c->validate(); // You can omit this if you want
+        $c->getCollection()->insert($c->toArray());
+    }
 
 ##Known bugs
-
-at this stage, it can have some ;]
+Remember, this is not complete yet. So at this stage, it can have some ;]
+If you find any please let me know
 
 ##Changelog
 
@@ -336,7 +335,7 @@ at this stage, it can have some ;]
 ##Resources
 
  * [Project page](https://github.com/canni/YiiMongoDbSuite/)
- * [MongoDB documentaction](http://www.mongodb.org/display/DOCS/Home)
+ * [MongoDB documentation](http://www.mongodb.org/display/DOCS/Home)
  * [PHP MongoDB Driver docs](http://www.php.net/manual/en/book.mongo.php)
 
 ##Contribution needed!


### PR DESCRIPTION
~~~ [php] ~~~ code blocks do not work on github readme pages. Which was causing the readme on github to be broken and diffucult to read. So I removed the ~ tags and used standard 4 space indentation to create code blocks. The ~~~ blocks were breaking githubs readme so not it is easier to read on github. This change will work on the yii wiki pages, but the syntax highlighting will not work because github readme files cannot be syntax highlighted. To see an example of what it looks like before you pull this commit, you can look at the readme on my fork here:
https://github.com/luckysmack/YiiMongoDbSuite

If you do not want to merge this that is ok. If you do not I will make a seperate branch to keep these changes so they do not get pushed to your repo when you pull from mine.
