### PR TITLE
Fix related to embedded documents

### DIFF
--- a/extra/EEmbeddedArraysBehavior.php
+++ b/extra/EEmbeddedArraysBehavior.php
@@ -90,4 +90,12 @@ class EEmbeddedArraysBehavior extends EMongoDocumentBehavior
 		else
 			return false;
 	}
+
+	/**
+	 * Event: re-initialize array of embedded documents which where toArray()ized by beforeSave()
+	 */
+	public function afterSave($event)
+	{
+		$this->parseExistingArray();
+	}
 }


### PR DESCRIPTION
embedded documents are converted to array during beforeSave(). This fix revert element to correct embedded documents during afterSave()
