### PR TITLE
F/instant cursor

### DIFF
--- a/EMongoCriteria.php
+++ b/EMongoCriteria.php
@@ -74,6 +74,7 @@ class EMongoCriteria extends CComponent
 	private $_conditions	= array();
 	private $_sort			= array();
 	private $_workingFields	= array();
+	private $_useCursor		= null;
 
 	/**
 	 * Constructor
@@ -135,6 +136,8 @@ class EMongoCriteria extends CComponent
 				$this->offset($criteria['offset']);
 			if(isset($criteria['sort']))
 				$this->setSort($criteria['sort']);
+			if(isset($criteria['useCursor']))
+				$this->setUseCursor($criteria['useCursor']);
 		}
 		else if($criteria instanceof EMongoCriteria)
 			$this->mergeWith($criteria);
@@ -317,6 +320,22 @@ class EMongoCriteria extends CComponent
 	public function setSort(array $sort)
 	{
 		$this->_sort = $sort;
+	}
+
+	/**
+	 * @since v1.3.7
+	 */
+	public function getUseCursor()
+	{
+		return $this->_useCursor;
+	}
+
+	/**
+	 * @since v1.3.7
+	 */
+	public function setUseCursor($useCursor)
+	{
+		$this->_useCursor = $useCursor;
 	}
 
 	/**

--- a/EMongoCriteria.php
+++ b/EMongoCriteria.php
@@ -202,7 +202,7 @@ class EMongoCriteria extends CComponent
 	{
 		if(isset($parameters[0]))
 			$operatorName = strtolower($parameters[0]);
-		if(isset($parameters[1]))
+		if(isset($parameters[1]) || ($parameters[1] === null))
 			$value = $parameters[1];
 
 		if(is_numeric($operatorName))

--- a/EMongoDocument.php
+++ b/EMongoDocument.php
@@ -319,13 +319,16 @@ abstract class EMongoDocument extends EMongoEmbeddedDocument
 	 * Get value of use cursor flag
 	 *
 	 * It will return the nearest not null value in order:
+	 * - Criteria level
 	 * - Object level
 	 * - Model level
 	 * - Glopal level (always set)
 	 * @return boolean
 	 */
-	public function getUseCursor()
+	public function getUseCursor($criteria = null)
 	{
+		if($criteria !== null && $criteria->getUseCursor() !== null)
+			return $criteria->getUseCursor();
 		if($this->useCursor !== null)
 			return $this->useCursor; // We have flag set, return it
 		if((isset(self::$_models[get_class($this)]) === true) && (self::$_models[get_class($this)]->useCursor !== null))
@@ -855,7 +858,7 @@ abstract class EMongoDocument extends EMongoEmbeddedDocument
 			if($criteria->getSelect())
 				$cursor->fields($criteria->getSelect(true));
 
-			if($this->getUseCursor())
+			if($this->getUseCursor($criteria))
 				return new EMongoCursor($cursor, $this->model());
 			else
 				return $this->populateRecords($cursor);


### PR DESCRIPTION
Hi,

I've added the possibility to supply the useCursor value directly with the Criteria. This been found very useful when creating dependent code on the return value of a find method. This way it's unnecessary to back up the previous value, set to to the desired, then after the query set it back.

Test cases are pushed to the same named branch at https://github.com/mrbig/YiiMongoDbSuite-testingApp/tree/f/instantCursor
