### PR TITLE
B/negative select

### DIFF
--- a/EMongoCriteria.php
+++ b/EMongoCriteria.php
@@ -348,10 +348,9 @@ class EMongoCriteria extends CComponent
 	 *                the fields in this format
 	 * @since v1.3.1
 	 */
-	public function getSelect($forCursor = false)
+	public function getSelect()
 	{
-		if (!$forCursor) return $this->_select;
-		return array_fill_keys($this->_select, true); // PHP 5.2.0+ required!
+		return $this->_select;
 	}
 
 	/**
@@ -359,7 +358,17 @@ class EMongoCriteria extends CComponent
 	 */
 	public function setSelect(array $select)
 	{
-		$this->_select = $select;
+		$this->_select = array();
+		// Convert the select array to field=>true/false format
+		foreach ($select as $key=>$value) {
+			if (is_int($key)) {
+				$this->_select[$value] = true;
+			}
+			else
+			{
+				$this->_select[$key] = $value;
+			}
+		}
 	}
 
 	/**
@@ -388,7 +397,7 @@ class EMongoCriteria extends CComponent
 	public function select(array $fieldList=null)
 	{
 		if($fieldList!==null)
-			$this->_select = array_merge($this->_select, $fieldList);
+			$this->setSelect(array_merge($this->_select, $fieldList));
 		return $this;
 	}
 

--- a/EMongoDocument.php
+++ b/EMongoDocument.php
@@ -851,7 +851,7 @@ abstract class EMongoDocument extends EMongoEmbeddedDocument
 			if($criteria->getOffset() !== null)
 				$cursor->skip($criteria->getOffset());
 			if($criteria->getSelect())
-				$cursor->fields($criteria->getSelect(true));
+				$cursor->fields($criteria->getSelect());
 
 			if($this->getUseCursor($criteria))
 				return new EMongoCursor($cursor, $this->model());


### PR DESCRIPTION
Hi!

I've found a bug in the partial document load, where the findAll method did not work as expected when negative criteria was used (fields to be excluded were specified). I've refactored a bit how the criteria keeps track of the selected fields, now it's always converted to the fieldname=>true/false format.

Please merge it into devel when you have some time.
