### PR TITLE
b/array owners

### DIFF
--- a/extra/EEmbeddedArraysBehavior.php
+++ b/extra/EEmbeddedArraysBehavior.php
@@ -100,6 +100,7 @@ class EEmbeddedArraysBehavior extends EMongoDocumentBehavior
 			{
 				$obj = new $this->arrayDocClassName;
 				$obj->setAttributes($doc, false);
+				$obj->setOwner($this->getOwner());
 				
 				// If any EEmbeddedArraysBehavior is attached,
 				// then we should trigger parsing of the newly set


### PR DESCRIPTION
Bug partially fixed: embedded documents in array did not get the owner set

The owner is only set after loading the documents from the db. I did not
found a way to catch the event when the document is added to the array
thus I was not able to set the owner in this case.

I've also added testcases for this bug in the test app, please pull that too.
