### PR TITLE
F/aftersetattributes event

### DIFF
--- a/EMongoDocumentBehavior.php
+++ b/EMongoDocumentBehavior.php
@@ -25,7 +25,8 @@ class EMongoDocumentBehavior extends CActiveRecordBehavior
 			'onBeforeEmbeddedDocsInit'=>'beforeEmbeddedDocsInit',
 			'onAfterEmbeddedDocsInit'=>'afterEmbeddedDocsInit',
 			'onBeforeToArray'=>'beforeToArray',
-			'onAfterToArray'=>'afterToArray'
+			'onAfterToArray'=>'afterToArray',
+			'onAfterSetAttributes'=>'afterSetAttributes',
 		));
 	}
 
@@ -33,4 +34,5 @@ class EMongoDocumentBehavior extends CActiveRecordBehavior
 	public function afterEmbeddedDocsInit($event){}
 	public function beforeToArray($event){}
 	public function afterToArray($event){}
+	public function afterSetAttributes($event){}
 }

--- a/EMongoEmbeddedDocument.php
+++ b/EMongoEmbeddedDocument.php
@@ -116,6 +116,14 @@ abstract class EMongoEmbeddedDocument extends CModel
 	}
 
 	/**
+	 * @since v1.3.6.x
+	 */
+	public function onAfterSetAttributes($event)
+	{
+		$this->raiseEvent('onAfterSetAttributes', $event);
+	}
+
+	/**
 	 * @since v1.0.8
 	 */
 	protected function beforeToArray()
@@ -131,6 +139,14 @@ abstract class EMongoEmbeddedDocument extends CModel
 	protected function afterToArray()
 	{
 		$this->onAfterToArray(new CModelEvent($this));
+	}
+
+	/**
+	 * @since v1.3.6.x
+	 */
+	protected function afterSetAttributes()
+	{
+		$this->onAfterSetAttributes(new CModelEvent($this));
 	}
 
 	/**
@@ -205,6 +221,21 @@ abstract class EMongoEmbeddedDocument extends CModel
 		}
 		else
 			return parent::__isset($name);
+	}
+	
+	/**
+	 * Sets the attribute values in a massive way.
+	 * We will raise an afterSetAttributes event for behaviors
+	 * @param array $values attribute values (name=>value) to be set.
+	 * @param boolean $safeOnly whether the assignments should only be done to the safe attributes.
+	 * A safe attribute is one that is associated with a validation rule in the current {@link scenario}.
+	 * @see getSafeAttributeNames
+	 * @see attributeNames
+	 */
+	public function setAttributes($values,$safeOnly=true)
+	{
+		parent::setAttributes($values,$safeOnly);
+		$this->afterSetAttributes();
 	}
 
 	/**

--- a/extra/EEmbeddedArraysBehavior.php
+++ b/extra/EEmbeddedArraysBehavior.php
@@ -81,9 +81,9 @@ class EEmbeddedArraysBehavior extends EMongoDocumentBehavior
 
 	/**
 	 * Event: initialize array of embded documents
-	 * @since v1.0
+	 * @since v1.3.6.x
 	 */
-	public function afterEmbeddedDocsInit($event)
+	public function afterSetAttributes($event)
 	{
 		$this->parseExistingArray();
 	}
@@ -102,15 +102,6 @@ class EEmbeddedArraysBehavior extends EMongoDocumentBehavior
 				$obj->setAttributes($doc, false);
 				$obj->setOwner($this->getOwner());
 
-				// If any EEmbeddedArraysBehavior is attached,
-				// then we should trigger parsing of the newly set
-				// attributes
-				foreach (array_keys($obj->behaviors()) as $name) {
-					$behavior = $obj->asa($name);
-					if ($behavior instanceof EEmbeddedArraysBehavior) {
-						$behavior->parseExistingArray();
-					}
-				}
 				$arrayOfDocs[] = $obj;
 			}
 			$this->getOwner()->{$this->arrayPropertyName} = $arrayOfDocs;


### PR DESCRIPTION
Hi!

Yet another refactor to the EEmbeddedArraysBehavior. The behavior did not work on embedded documents: it tried to load the attributes before the setAttributes was called.

Now EMongoEmbeddedDocument raises a new event called afterSetAttributes. This
is raised after the attributes of the document have been set.

EEmbeddedArraysBehavior changed to populate the items on this event. This
makes it more robust when attached to embedded documents.

I'll add some testcases for this in the test suite hopefully in a few days. This fix has been tested on out project that has many different use of the EmbeddedArraysBehavior, and didn't brake anything, so seems safe to me.
