### PR TITLE
Updating unique validator to ignore matches with same pk.

### DIFF
--- a/extra/EMongoUniqueValidator.php
+++ b/extra/EMongoUniqueValidator.php
@@ -28,7 +28,9 @@ class EMongoUniqueValidator extends CValidator
 			return;
 
 		$criteria = new EMongoCriteria;
-		$criteria->{$attribute} = $value;
+		if(!$object->getIsNewRecord())
+			$criteria->addCond('_id', '!=', $object->getPrimaryKey());
+		$criteria->addCond($attribute, '==', $value);
 		$count = $object->model()->count($criteria);
 
 		if($count !== 0)


### PR DESCRIPTION
Currently the unique validator does not ensure that records with the same pk are ignored. Patch to ignore same pk.
